### PR TITLE
Replaced Old Button Components With a Simplified Version

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -1,62 +1,46 @@
-import styled, { keyframes } from 'styled-components';
-import { ButtonProps } from './models';
+import styled from 'styled-components';
+import { ripple } from '../utils/animations';
+import { NatesButtonProps } from './models';
 
-const ripple = keyframes`
-  0% {
-    width: 0;
-    opacity: .3;
-  }
-  100% {
-    width: 400%;
-    opacity: 0;
-  }
-`;
-
-export const ButtonContent = styled.div<ButtonProps>`
-  display: inline;
-  position: relative;
-  pointer-events: none;
-  z-index: 100;
-  margin: 0;
-  padding: 0;
-  color: ${({ color, ghost, theme: { colors } }) =>
-    ghost ? colors[color || 'white'] : 'whitesmoke'};
-`;
-
-export const ErrorIcon = styled.strong`
-  letter-spacing: -0.5rem;
-  filter: drop-shadow(0 0 2px #f1f3de);
-`;
-
-export const NatesButton = styled.button<ButtonProps>`
-  position: relative;
-  z-index: ${({ z, theme }) => (z ? theme.zIndices[z] : '')};
-  isolation: isolate;
-
-  font-size: ${({ theme, size }) => theme.fontSizes[size || 'md'] || '1rem'};
-  font-weight: 600;
-  padding: calc(${({ theme, size }) => theme.space[size || 'md']} / 3)
-    calc(${({ theme, size }) => theme.space[size || 'md']} * 2);
-  cursor: pointer;
-  contain: paint;
-  border: ${({ ghost, color, theme: { colors } }) =>
-    ghost ? `2px solid ${colors[color || 'primary']}` : 'none'};
-  border-radius: ${({ radi }) => radi || '.5rem'};
-  background-color: ${({ color, ghost, theme: { colors } }) =>
-    ghost ? 'transparent' : color ? colors[color] || color : '#1a75f1'};
-
+// prettier-ignore
+export const NatesStyledButton = styled.button<NatesButtonProps>`
+  ${({ color, ghost, z, size, radi, theme: { colors, fontSizes, fontWeights, zIndices, space },
+  }) => ({
+    position: 'relative',
+    zIndex: z ? zIndices[z] || z : '',
+    isolation: 'isolate',
+    fontSize: fontSizes[size || 'md'] || '1rem',
+    fontWeight: 600,
+    padding: `calc(${space[size || 'md'] || '1rem'} / 3) calc(${ space[size || 'md'] || '1rem' } * 2)`,
+    cursor: 'pointer',
+    contain: 'paint',
+    border: ghost ? `2px solid ${colors[color || 'primary'] || 'gray'}` : 'none',
+    borderRadius: radi || '.5em',
+    backgroundColor: ghost ? 'transparent' : color ? colors[color] || color : '#1a75f1',
+  })}
   span {
     position: absolute;
     z-index: 50;
     aspect-ratio: 1;
     border-radius: 50%;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+
     background: ${({ color, ghost, theme: { colors } }) =>
       ghost ? colors[color || 'white'] : 'whitesmoke'};
-
-    pointer-events: none;
-
-    transform: translate(-50%, -50%);
 
     animation: ${ripple} 500ms linear infinite;
   }
 `;
+
+export const NatesButtonContent = styled.div<NatesButtonProps>(
+  ({ color, ghost, theme: { colors } }) => ({
+    display: 'inline',
+    position: 'relative',
+    pointerEvents: 'none',
+    zIndex: 100,
+    margin: 0,
+    padding: 0,
+    color: ghost ? colors[color || 'white'] : 'whitesmoke',
+  }),
+);

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,22 +1,7 @@
 import React, { useRef } from 'react';
-import { ButtonContent, ErrorIcon, NatesButton } from './Button.styled';
-import { ButtonProps } from './models';
-
-const createRipple = (
-  e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  buttonRef: React.RefObject<HTMLButtonElement>,
-) => {
-  const span = document.createElement('span');
-
-  span.style.top = e.clientY - e.currentTarget.offsetTop + 'px';
-  span.style.left = e.clientX - e.currentTarget.offsetLeft + 'px';
-
-  buttonRef.current?.appendChild(span);
-
-  setTimeout(() => {
-    span.remove();
-  }, 500);
-};
+import { createRipple } from '../utils/animations';
+import { NatesButtonContent, NatesStyledButton } from './Button.styled';
+import { NatesButtonProps } from './models';
 
 /**
  * This Component is a Dynamic Button Component Built in Typescript.
@@ -24,62 +9,34 @@ const createRipple = (
  * Styles Can Be overridden but if you really want to change the look of it Id recoment looking into the docs of the library.
  * it might just have an easier way to do what you want.
  *
- *
- * -- type='text' caviate
- * - placholder attribute is purposefully set to an single space so that we can get the effect we achieve
- *
  * {@link https://github.com/NateAyye/nates-ts-react-components GithubRepo/wTutorial}
  *
- * @param id Will add the htmlFor on the label and will also add the id to the input
  * @param radi Can accept any valid CSS border-radius value
- * @param type
  * @param z The Z-index of the button
- * @param error Will change the style a lil bit and add an icon (Icon can be turned off with the errorIcon)
- * @param labelProps? If you'd like to add attributes to the label specificly you can do that all within this prop
+ * @param ripple Adding this will turn off the default ripple that comes with the Button
+ * @param ghost Adding this attribute will turn the buttons background-color transparent and give it a border with the same color as the color attribute( ripple effect will also be this color)
  *
  * @returns Custom Input Component that is a container containing a <labal> and an <input>
  *
  * @default
  * radi = '.5rem'
  */
-export const Button: React.FC<ButtonProps> = ({
-  onClick,
+export const Button: React.FC<NatesButtonProps> = ({
   children,
+  onClick,
   ...props
 }) => {
-  const { radi, icon, noIcon, errorIcon, ripple, size, z, ghost } = props;
-  const styledProps = {
-    radi,
-    icon,
-    noIcon,
-    errorIcon,
-    ripple,
-    size,
-    z,
-    ghost,
-  };
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const { ripple, ghost, z, color, size } = props;
+  const styledProps = { ripple, ghost, z, color, size };
 
-  const handleButtonClick = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) => {
+  function handleOnClick(e: React.MouseEvent<HTMLButtonElement>) {
     if (onClick) onClick(e);
-    if (!ripple) {
-      createRipple(e, buttonRef);
-    }
-  };
-
+    if (!ripple) createRipple(e, buttonRef);
+  }
   return (
-    <NatesButton
-      ref={buttonRef}
-      onClick={handleButtonClick}
-      {...styledProps}
-      {...props}
-    >
-      <ButtonContent color={props.color} {...styledProps}>
-        {children}
-      </ButtonContent>
-      <ErrorIcon {...styledProps}>{noIcon ? null : icon}</ErrorIcon>
-    </NatesButton>
+    <NatesStyledButton ref={buttonRef} onClick={handleOnClick} {...props}>
+      <NatesButtonContent {...styledProps}>{children}</NatesButtonContent>
+    </NatesStyledButton>
   );
 };

--- a/src/components/Button/models.ts
+++ b/src/components/Button/models.ts
@@ -1,18 +1,11 @@
-import { CSSProperties } from 'styled-components';
-import { FontSizeKeys, ZIndicesKeys } from '../../themes';
+import { FontSizeKeys, ZIndicesKeys } from "../../themes";
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface NatesButtonProps
+  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'placeholder'> {
   children?: React.ReactNode | React.ReactNode[];
-  radi?: string;
-  icon?: string;
-  noIcon?: boolean;
-  errorIcon?: string;
   ripple?: boolean;
   size?: FontSizeKeys;
-  ghost?: boolean;
+  radi?: string;
   z?: ZIndicesKeys;
-  fg?: CSSProperties['color'];
-  /** Will Change the style a little bit and display an error icon if you don't want an Icon set the errorIcon */
-  error?: boolean;
+  ghost?: boolean;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+// Button Exports
 export * from './Button';
 export * from './Button/models';
 //  Form Exports

--- a/src/components/utils/animations.tsx
+++ b/src/components/utils/animations.tsx
@@ -1,0 +1,28 @@
+import { keyframes } from "styled-components";
+
+export const ripple = keyframes`
+  0% {
+    width: 0;
+    opacity: .3;
+  }
+  100% {
+    width: 400%;
+    opacity: 0;
+  }
+`;
+
+export const createRipple = (
+  e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  buttonRef: React.RefObject<HTMLButtonElement>,
+) => {
+  const span = document.createElement('span');
+
+  span.style.top = e.clientY - e.currentTarget.offsetTop + 'px';
+  span.style.left = e.clientX - e.currentTarget.offsetLeft + 'px';
+
+  buttonRef.current?.appendChild(span);
+
+  setTimeout(() => {
+    span.remove();
+  }, 500);
+};

--- a/src/pages/Button.tsx
+++ b/src/pages/Button.tsx
@@ -54,9 +54,7 @@ export const ButtonPage: React.FC<ButtonPageProps> = ({}) => {
       <Button color="error" size="sm" onClick={handleMouseClick}>
         Hello
       </Button>
-      <Button color="error">
-        Default
-      </Button>
+      <Button color="error">Default</Button>
       <Button color="error" size="lg">
         Default
       </Button>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { Button } from '../components';
+import React, { useRef } from 'react';
+import { Button } from '../components/Button';
 
 interface HomeProps {}
 
 export const Home: React.FC<HomeProps> = ({}) => {
+  const tempRef = useRef<HTMLButtonElement>(null);
+
   return (
     <div>
       <h1>Home</h1>
-      <Button>Button v2</Button>
+      <Button size="lg">Button v2</Button>
     </div>
   );
 };


### PR DESCRIPTION
## New Button 

Same as the old one just took off most of the icon and error handling since I want most of that to be handled by the color attribute. and if people really want to add Icons they can just do it in the children of the button.

All files required for the Button are within the components/Button folder .
I separated the styled components and interfaces from the actual component to have a cleaner codebase in general so now If I don't want people to export the base styled components I don't have to.

### Type
```ts

export interface NatesButtonProps
  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'placeholder'> {
  children?: React.ReactNode | React.ReactNode[];
  ripple?: boolean;
  size?: FontSizeKeys;
  radi?: string;
  z?: ZIndicesKeys;
  ghost?: boolean;
}
```

### Main Button Component
```ts
export const Button: React.FC<NatesButtonProps> = ({
  children,
  onClick,
  ...props
}) => {
  const buttonRef = useRef<HTMLButtonElement>(null);
  const { ripple, ghost, z, color, size } = props;
  const styledProps = { ripple, ghost, z, color, size };

  function handleOnClick(e: React.MouseEvent<HTMLButtonElement>) {
    if (onClick) onClick(e);
    if (!ripple) createRipple(e, buttonRef);
  }
  return (
    <NatesStyledButton ref={buttonRef} onClick={handleOnClick} {...props}>
      <NatesButtonContent {...styledProps}>{children}</NatesButtonContent>
    </NatesStyledButton>
  );
};
```


